### PR TITLE
Do not automatically attempt to resolve the round when editing an inactive event.

### DIFF
--- a/player.php
+++ b/player.php
@@ -269,7 +269,6 @@ function print_submit_resultForm($match_id, $drop = false)
     echo "<tr><td><input type='radio' name='report' value='W21' />I won the match 2-1</td> </tr>";
     echo "<tr><td><input type='radio' name='report' value='L20' />I lost the match 0-2 </td> </tr>";
     echo "<tr><td><input type='radio' name='report' value='L21' />I lost the match 1-2</td> </tr>";
-    echo "<tr><td><input type='radio' name='report' value='WO' />My opponent doesn't shows up</td> </tr>";
     if ($match->allowsPlayerReportedDraws() == 1) {
         echo "<tr><td><input type='radio' name='report' value='D' />The match was a draw</td> </tr>";
     }
@@ -333,9 +332,6 @@ function print_verify_resultForm($report, $match_id, $player, $drop, $opponent, 
             break;
         case 'L21':
             echo 'I lost the match 1-2';
-            break;
-        case 'WO':
-            echo 'My opponent doesn\'t show up';
             break;
         case 'D':
             echo 'The match was a draw';
@@ -812,10 +808,10 @@ function print_recentMatchTable()
     foreach ($matches as $match) {
         $res = 'Draw';
         if ($match->playerWon($player->name)) {
-            $res = 'Win'.($match->result == 'WO' ? ' Noshow' : '');
+            $res = 'Win';
         }
         if ($match->playerLost($player->name)) {
-            $res = 'Loss'.($match->result == 'WO' ? ' Noshow' : '');
+            $res = 'Loss';
         }
         if ($match->playera == $match->playerb) {
             $res = 'BYE';

--- a/player.php
+++ b/player.php
@@ -269,6 +269,7 @@ function print_submit_resultForm($match_id, $drop = false)
     echo "<tr><td><input type='radio' name='report' value='W21' />I won the match 2-1</td> </tr>";
     echo "<tr><td><input type='radio' name='report' value='L20' />I lost the match 0-2 </td> </tr>";
     echo "<tr><td><input type='radio' name='report' value='L21' />I lost the match 1-2</td> </tr>";
+    echo "<tr><td><input type='radio' name='report' value='WO' />My opponent doesn't shows up</td> </tr>";
     if ($match->allowsPlayerReportedDraws() == 1) {
         echo "<tr><td><input type='radio' name='report' value='D' />The match was a draw</td> </tr>";
     }
@@ -332,6 +333,9 @@ function print_verify_resultForm($report, $match_id, $player, $drop, $opponent, 
             break;
         case 'L21':
             echo 'I lost the match 1-2';
+            break;
+        case 'WO':
+            echo 'My opponent doesn\'t show up';
             break;
         case 'D':
             echo 'The match was a draw';
@@ -808,10 +812,10 @@ function print_recentMatchTable()
     foreach ($matches as $match) {
         $res = 'Draw';
         if ($match->playerWon($player->name)) {
-            $res = 'Win';
+            $res = 'Win'.($match->result=="WO"?' Noshow':'');
         }
         if ($match->playerLost($player->name)) {
-            $res = 'Loss';
+            $res = 'Loss'.($match->result=="WO"?' Noshow':'');
         }
         if ($match->playera == $match->playerb) {
             $res = 'BYE';
@@ -855,7 +859,7 @@ function print_currentMatchTable($Leagues)
             leagueOpponentDropMenu($event, $round = 1);
             echo '</td></tr></table>';
         }
-
+        
         if ($match->result != 'BYE') {
             $oppplayer = new Player($opp);
             echo '<tr><td>';

--- a/player.php
+++ b/player.php
@@ -812,10 +812,10 @@ function print_recentMatchTable()
     foreach ($matches as $match) {
         $res = 'Draw';
         if ($match->playerWon($player->name)) {
-            $res = 'Win'.($match->result=="WO"?' Noshow':'');
+            $res = 'Win'.($match->result == 'WO' ? ' Noshow' : '');
         }
         if ($match->playerLost($player->name)) {
-            $res = 'Loss'.($match->result=="WO"?' Noshow':'');
+            $res = 'Loss'.($match->result == 'WO' ? ' Noshow' : '');
         }
         if ($match->playera == $match->playerb) {
             $res = 'BYE';
@@ -859,7 +859,7 @@ function print_currentMatchTable($Leagues)
             leagueOpponentDropMenu($event, $round = 1);
             echo '</td></tr></table>';
         }
-        
+
         if ($match->result != 'BYE') {
             $oppplayer = new Player($opp);
             echo '<tr><td>';


### PR DESCRIPTION
After resolving a round, only pair the next round if the event is active.

I need this change for my test suites. I'm bulding several test events based on past events, and I don't want the pairing to be automated while the event is inactive. Only after I set the event as active, then the code can do the pairing automatically. And I assume some TO would need this feature as well in cases where they need to fix result from past events.

Fixes #139 