### PR TITLE
Fix for invalid event name in CTA

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,7 +18,7 @@ if (!is_null($player)) {
             }
         }
         $recent = $series->mostRecentEvent();
-        if (!$recent->finalized) {
+        if (!$recent->finalized && !empty($recent->name)) {
             $message = "Your event <a href=\"event.php?event={$recent->name}\">{$recent->name}</a> is ready to start. <br />";
             $reg = count($recent->getPlayers());
             $valid = count($recent->getRegisteredPlayers());


### PR DESCRIPTION
The production server at gatherling.com has an event named '' (Empty String).  This prevents you from getting a CTA that "Your event  is ready to start"