### PR TITLE
Disable Drop Input for Single Elimination

### DIFF
--- a/player.php
+++ b/player.php
@@ -275,7 +275,9 @@ function print_submit_resultForm($match_id, $drop = false)
         echo "<tr><td><input type='radio' name='report' value='D' />The match was a draw</td> </tr>";
     }
     echo '<tr><td></td></tr>';
-    print_checkbox_input('I want to drop from this event', 'drop', $drop);
+    if($match->type !== 'Single Elimination') {
+        print_checkbox_input('I want to drop from this event', 'drop', $drop);
+    }
     echo '<tr><td></td></tr>';
     echo '<tr><td class="buttons">';
     echo '<input class="inputbutton" name="submit" type="submit" value="Submit Match Report" />';

--- a/player.php
+++ b/player.php
@@ -275,7 +275,7 @@ function print_submit_resultForm($match_id, $drop = false)
         echo "<tr><td><input type='radio' name='report' value='D' />The match was a draw</td> </tr>";
     }
     echo '<tr><td></td></tr>';
-    if($match->type !== 'Single Elimination') {
+    if ($match->type !== 'Single Elimination') {
         print_checkbox_input('I want to drop from this event', 'drop', $drop);
     }
     echo '<tr><td></td></tr>';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Disable Drop Input for Single Elimination


* **What is the current behavior?** (You can also link to an open issue here)
Player can drop themselves during Single Elimination rounds, which would break the pairing system


* **What is the new behavior (if this is a feature change)?**
Player can't drop themselves during Single Elimination rounds


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Closing issues**
fixes #169 